### PR TITLE
Add idb to search order for persist.js

### DIFF
--- a/cog/persist.js
+++ b/cog/persist.js
@@ -142,6 +142,7 @@ return r;},version:'0.2.1',enabled:false};me.enabled=alive.call(me);return me;}(
      */
     search_order: [
       // TODO: air
+      'idb',
       'cefStorage',
       'winOldStorage',
       'winStoreStorage',


### PR DESCRIPTION
As is it won't actually use idb, as it fails to search.